### PR TITLE
suppress potential ssh2_exec() warning

### DIFF
--- a/src/SftpClient.php
+++ b/src/SftpClient.php
@@ -251,7 +251,7 @@ class SftpClient
     public function close()
     {
         $this->validateSshResource();
-        ssh2_exec($this->getSshResource(), 'exit');
+        @ssh2_exec($this->getSshResource(), 'exit');
         $this->setSftpResource(null);
         $this->setSshResource(null);
 


### PR DESCRIPTION
This suppresses the following warning when using `ssh2_exec()`:
`Warning: ssh2_exec(): Unable to request command execution on remote host`
