### PR TITLE
fix closing a connection

### DIFF
--- a/src/SftpClient.php
+++ b/src/SftpClient.php
@@ -262,7 +262,7 @@ class SftpClient
     {
         if ($this->getSshResource()) {
             $this->validateSshResource();
-            ssh2_exec($this->getSshResource(), 'logout');
+            ssh2_disconnect($this->getSshResource());
             $this->setSftpResource(null);
             $this->setSshResource(null);
         }


### PR DESCRIPTION
This PR fix the close method.

In the right way, ssh2 connections should be closed with ssh2_disconnect().
Actually, it dosen't work correctly with ssh2_exec($this->getSshResource(), 'logout').